### PR TITLE
1.0.2

### DIFF
--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -21,6 +21,9 @@ import xyz.mytang0.brook.spi.task.FlowTask;
 
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -145,11 +148,21 @@ public class LoopTask implements FlowTask {
                 evaluated = loopOverRaw;
             }
 
+            // Normalize to List: accept List, Collection, Iterable, and arrays.
             if (evaluated instanceof List) {
                 loopOverValue = (List<Object>) evaluated;
+            } else if (evaluated != null && evaluated.getClass().isArray()) {
+                loopOverValue = Arrays.asList((Object[]) evaluated);
+            } else if (evaluated instanceof Collection) {
+                loopOverValue = new ArrayList<>((Collection<?>) evaluated);
+            } else if (evaluated instanceof Iterable) {
+                loopOverValue = new ArrayList<>();
+                for (Object item : (Iterable<?>) evaluated) {
+                    loopOverValue.add(item);
+                }
             } else {
                 throw new IllegalArgumentException(
-                        "The loop task 'loopOver' must evaluate to a list, got: "
+                        "The loop task 'loopOver' must evaluate to a list/collection/iterable, got: "
                                 + (evaluated == null ? "null" : evaluated.getClass().getName()));
             }
             iterations = loopOverValue.size();

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -69,7 +69,8 @@ public class LoopTask implements FlowTask {
     static final String INNER_LAST_TASK = "innerLastTask";
 
     // Separator used to create per-iteration unique task names.
-    static final String LOOP_INDEX_SEPARATOR = "__LOOP_";
+    // Public so ParameterUtils can inject loop-body aliases into the flow context.
+    public static final String LOOP_INDEX_SEPARATOR = "__LOOP_";
 
     // Keys that are specific to TaskDef (beyond "name" and "type") used to
     // distinguish real TaskDef Maps from arbitrary user payload Maps.

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -143,7 +143,7 @@ public class LoopTask implements FlowTask {
             Integer loopCount = taskDefInput.get(Options.LOOP_COUNT);
             if (loopCount == null || loopCount < 0) {
                 throw new IllegalArgumentException(
-                        "The loop task 'loopCount' must be a non-negative integer");
+                        "The loop task 'loopCount' must be specified and be a non-negative integer");
             }
             iterations = loopCount;
         }
@@ -200,7 +200,7 @@ public class LoopTask implements FlowTask {
         TaskInstance mappingTask = mappingTaskOptional.get();
 
         if (mappingTask.getOutput() == null) {
-            throw new IllegalStateException("When next, the LOOP task output null");
+            throw new IllegalStateException("LOOP task output must not be null when determining next task");
         }
 
         Map<String, Object> output = mappingTask.getOutput();
@@ -239,7 +239,7 @@ public class LoopTask implements FlowTask {
 
                     // Update current item if loopOver mode.
                     List<Object> loopOverValue = (List<Object>) output.get(LOOP_OVER_VALUE_KEY);
-                    if (loopOverValue != null) {
+                    if (loopOverValue != null && nextIndex < loopOverValue.size()) {
                         output.put(CURRENT_ITEM_KEY, loopOverValue.get(nextIndex));
                     }
 
@@ -269,7 +269,8 @@ public class LoopTask implements FlowTask {
                 if (loopBody == null) {
 
                     if (!(taskDef.getInput() instanceof Map)) {
-                        throw new IllegalArgumentException("The loop task input type is not map");
+                        throw new IllegalArgumentException(
+                            "Loop task input must be a Map");
                     }
 
                     loopBody = JsonUtils.convertValue(

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -102,7 +102,11 @@ public class LoopTask implements FlowTask {
         boolean hasLoopCount = configuration.contains(Options.LOOP_COUNT);
         if (!hasLoopOver && !hasLoopCount) {
             throw new ValidationException(
-                    "At least one of 'loopOver' or 'loopCount' must be specified");
+                    "Exactly one of 'loopOver' or 'loopCount' must be specified");
+        }
+        if (hasLoopOver && hasLoopCount) {
+            throw new ValidationException(
+                    "Only one of 'loopOver' or 'loopCount' may be specified");
         }
     }
 

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,10 +75,11 @@ public class LoopTask implements FlowTask {
     // distinguish real TaskDef Maps from arbitrary user payload Maps.
     // A Map must have "name" + "type" AND at least one of these keys to be
     // considered a TaskDef for per-iteration renaming.
-    private static final Set<String> TASK_DEF_INDICATOR_KEYS = new HashSet<>(Arrays.asList(
-            "input", "controlDef", "progressDef", "logDef", "linkDef",
-            "checkDef", "hangDef", "callback", "extension", "template"
-    ));
+    private static final Set<String> TASK_DEF_INDICATOR_KEYS =
+            new HashSet<>(Arrays.asList(
+                    "input", "controlDef", "progressDef", "logDef", "linkDef",
+                    "checkDef", "hangDef", "callback", "extension", "template"
+            ));
 
     private final EngineActuator engineActuator;
 
@@ -145,16 +145,16 @@ public class LoopTask implements FlowTask {
             // passing it through the engine would break (e.g., "[a, b]" is not a valid expression).
             Object evaluated;
             if (loopOverRaw instanceof String) {
-                evaluated = Optional.ofNullable(taskDefInput.getString(Options.ENGINE_TYPE))
-                        .filter(StringUtils::isNotBlank)
-                        .map(engineType ->
-                                engineActuator.compute(
-                                        engineType,
-                                        (String) loopOverRaw,
-                                        flowContext(context.getFlowInstance())
-                                )
-                        )
-                        .orElse(loopOverRaw);
+                String engineType = taskDefInput.getString(Options.ENGINE_TYPE);
+                if (StringUtils.isNotBlank(engineType)) {
+                    evaluated = engineActuator.compute(
+                            engineType,
+                            (String) loopOverRaw,
+                            flowContext(context.getFlowInstance())
+                    );
+                } else {
+                    evaluated = loopOverRaw;
+                }
             } else {
                 evaluated = loopOverRaw;
             }
@@ -208,7 +208,7 @@ public class LoopTask implements FlowTask {
             inputMap.put(Options.LOOP_OVER.key(), loopOverValue);
         }
 
-        Map<String, Object> loopOutput = new HashMap<>();
+        Map<String, Object> loopOutput = new HashMap<>(4);
         loopOutput.put(ITERATIONS_KEY, iterations);
         loopOutput.put(CURRENT_INDEX_KEY, 0);
         if (loopOverValue != null && !loopOverValue.isEmpty()) {
@@ -289,15 +289,10 @@ public class LoopTask implements FlowTask {
             // Create iteration-specific copies of loopBody with __LOOP_<index> suffixed names,
             // so that flowExecutor.getNextTask() can match against the target (which was
             // also scheduled with suffixed names).
-            List<TaskDef> iterationBody = new ArrayList<>();
-            for (TaskDef bodyTask : loopBody) {
-                iterationBody.add(createIterationTaskDef(bodyTask, effectiveIndex));
-            }
-
             // Traverse using flowExecutor.getNextTask() (like IFTask/SwitchTask do)
             // so that nested control-flow tasks (IF/SWITCH/SUB_FLOW) within the loop body
             // are properly traversed instead of relying on top-level name matching.
-            nextTask = findNextTaskFromChildren(iterationBody, target);
+            nextTask = findNextTaskFromChildren(loopBody, target, effectiveIndex);
 
             if (nextTask == TaskDef.MATCHED) {
                 // All tasks in current iteration completed, advance to next.
@@ -318,6 +313,7 @@ public class LoopTask implements FlowTask {
 
         return nextTask;
     }
+
     /**
      * Traverses loop body children using flowExecutor.getNextTask() to properly
      * support nested control-flow tasks (IF/SWITCH/SUB_FLOW). When getNextTask()
@@ -325,16 +321,19 @@ public class LoopTask implements FlowTask {
      * no more siblings exist). This follows the same pattern as IFTask/SwitchTask.
      */
     @SuppressWarnings("all")
-    private TaskDef findNextTaskFromChildren(final List<TaskDef> children,
-                                             final TaskDef target) {
-        Iterator<TaskDef> iterator = children.iterator();
+    private TaskDef findNextTaskFromChildren(
+            final List<TaskDef> loopBody,
+            final TaskDef target,
+            final int iterationIndex) {
 
-        while (iterator.hasNext()) {
-            TaskDef nextTask =
-                    flowExecutor.getNextTask(iterator.next(), target);
+        for (int i = 0; i < loopBody.size(); i++) {
+            TaskDef nextTask = flowExecutor.getNextTask(
+                    createIterationTaskDef(loopBody.get(i), iterationIndex),
+                    target
+            );
             if (nextTask == TaskDef.MATCHED) {
-                return iterator.hasNext()
-                        ? iterator.next()
+                return (i + 1) < loopBody.size()
+                        ? createIterationTaskDef(loopBody.get(i + 1), iterationIndex)
                         : TaskDef.MATCHED;
             } else if (nextTask != null) {
                 return nextTask;
@@ -354,15 +353,53 @@ public class LoopTask implements FlowTask {
      */
     private TaskDef createIterationTaskDef(TaskDef original, int iterationIndex) {
         String suffix = LOOP_INDEX_SEPARATOR + iterationIndex;
-        TaskDef copy = JsonUtils.readValue(
-                JsonUtils.toJsonString(original), TaskDef.class);
+
+        TaskDef copy = new TaskDef();
+        copy.setType(original.getType());
         copy.setName(original.getName() + suffix);
+        copy.setDisplay(original.getDisplay());
+        copy.setDescription(original.getDescription());
+        copy.setControlDef(original.getControlDef());
+        copy.setProgressDef(original.getProgressDef());
+        copy.setLogDef(original.getLogDef());
+        copy.setLinkDef(original.getLinkDef());
+        copy.setCheckDef(original.getCheckDef());
+        copy.setHangDef(original.getHangDef());
+        copy.setCallback(original.getCallback());
+        copy.setExtension(original.getExtension());
+        copy.setTemplate(original.getTemplate());
+
+        Object copiedInput = deepCopyInputObject(original.getInput());
+        copy.setInput(copiedInput);
+        copy.setOutput(original.getOutput());
+
         // Recursively rename any nested TaskDefs embedded in the input
         // (e.g., IF trueBranch/falseBranch, SWITCH cases, nested LOOP body).
-        if (copy.getInput() != null) {
-            renameNestedTaskDefs(copy.getInput(), suffix);
+        if (copiedInput != null) {
+            renameNestedTaskDefs(copiedInput, suffix);
         }
         return copy;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object deepCopyInputObject(Object input) {
+        if (input instanceof Map) {
+            Map<String, Object> original = (Map<String, Object>) input;
+            Map<String, Object> copied = new HashMap<>(original.size());
+            for (Map.Entry<String, Object> entry : original.entrySet()) {
+                copied.put(entry.getKey(), deepCopyInputObject(entry.getValue()));
+            }
+            return copied;
+        }
+        if (input instanceof List) {
+            List<?> original = (List<?>) input;
+            List<Object> copied = new ArrayList<>(original.size());
+            for (Object item : original) {
+                copied.add(deepCopyInputObject(item));
+            }
+            return copied;
+        }
+        return input;
     }
 
     /**
@@ -399,11 +436,16 @@ public class LoopTask implements FlowTask {
      * "controlDef"), to avoid false positives on arbitrary user data.
      */
     private static boolean isTaskDefMap(Map<String, Object> map) {
-        if (!(map.containsKey("name") && map.containsKey("type")
-                && map.get("name") instanceof String
-                && map.get("type") instanceof String)) {
+        Object name = map.get("name");
+        if (!(name instanceof String)) {
             return false;
         }
+
+        Object type = map.get("type");
+        if (!(type instanceof String)) {
+            return false;
+        }
+
         for (String key : TASK_DEF_INDICATOR_KEYS) {
             if (map.containsKey(key)) {
                 return true;

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -21,8 +21,8 @@ import xyz.mytang0.brook.spi.task.FlowTask;
 
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -149,10 +149,11 @@ public class LoopTask implements FlowTask {
             }
 
             // Normalize to List: accept List, Collection, Iterable, and arrays.
-            if (evaluated instanceof List) {
+            if (evaluated == null) {
+                throw new IllegalArgumentException(
+                        "The loop task 'loopOver' must evaluate to a list/collection/iterable, got: null");
+            } else if (evaluated instanceof List) {
                 loopOverValue = (List<Object>) evaluated;
-            } else if (evaluated != null && evaluated.getClass().isArray()) {
-                loopOverValue = Arrays.asList((Object[]) evaluated);
             } else if (evaluated instanceof Collection) {
                 loopOverValue = new ArrayList<>((Collection<?>) evaluated);
             } else if (evaluated instanceof Iterable) {
@@ -160,10 +161,16 @@ public class LoopTask implements FlowTask {
                 for (Object item : (Iterable<?>) evaluated) {
                     loopOverValue.add(item);
                 }
+            } else if (evaluated.getClass().isArray()) {
+                int length = Array.getLength(evaluated);
+                loopOverValue = new ArrayList<>(length);
+                for (int i = 0; i < length; i++) {
+                    loopOverValue.add(Array.get(evaluated, i));
+                }
             } else {
                 throw new IllegalArgumentException(
                         "The loop task 'loopOver' must evaluate to a list/collection/iterable, got: "
-                                + (evaluated == null ? "null" : evaluated.getClass().getName()));
+                                + evaluated.getClass().getName());
             }
             iterations = loopOverValue.size();
         } else {

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -381,11 +381,6 @@ public class LoopTask implements FlowTask {
                 || type.getName().startsWith("java.time.")
                 || type.getName().startsWith("java.lang.");
     }
-        }
-
-        return nextTask;
-    }
-
     /**
      * Creates a deep copy of a TaskDef with an iteration-specific name suffix.
      * This ensures each iteration's tasks have unique names, preventing

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -268,119 +269,71 @@ public class LoopTask implements FlowTask {
             output.put(CURRENT_INDEX_KEY, 0);
             nextTask = createIterationTaskDef(loopBody.get(0), 0);
         } else {
-            // Find the target's position in the loop body by stripping the iteration suffix.
-            String originalName = stripIterationSuffix(target.getName());
+            // Determine the current iteration index from the target's name suffix
+            // or fall back to the stored currentIndex.
             int iterationIndex = extractIterationIndex(target.getName());
-
-            int pos = findPositionInLoopBody(loopBody, originalName);
-
-            if (pos < 0) {
-                // Target not found in loop body.
-                return null;
-            }
-
             int effectiveIndex = iterationIndex >= 0
                     ? iterationIndex
                     : (int) output.get(CURRENT_INDEX_KEY);
 
-            if (pos + 1 < loopBody.size()) {
-                // More tasks in the current iteration.
-                nextTask = createIterationTaskDef(
-                        loopBody.get(pos + 1), effectiveIndex);
-            } else {
-                // Last task in the current iteration, advance to next.
+            // Create iteration-specific copies of loopBody with __LOOP_<index> suffixed names,
+            // so that flowExecutor.getNextTask() can match against the target (which was
+            // also scheduled with suffixed names).
+            List<TaskDef> iterationBody = new ArrayList<>();
+            for (TaskDef bodyTask : loopBody) {
+                iterationBody.add(createIterationTaskDef(bodyTask, effectiveIndex));
+            }
+
+            // Traverse using flowExecutor.getNextTask() (like IFTask/SwitchTask do)
+            // so that nested control-flow tasks (IF/SWITCH/SUB_FLOW) within the loop body
+            // are properly traversed instead of relying on top-level name matching.
+            nextTask = findNextTaskFromChildren(iterationBody, target);
+
+            if (nextTask == TaskDef.MATCHED) {
+                // All tasks in current iteration completed, advance to next.
                 int nextIndex = effectiveIndex + 1;
                 if (nextIndex < iterations) {
                     output.put(CURRENT_INDEX_KEY, nextIndex);
                     updateCurrentItem(output, mappingTask, nextIndex);
                     nextTask = createIterationTaskDef(
                             loopBody.get(0), nextIndex);
-                } else {
-                    // All iterations done.
-                    nextTask = TaskDef.MATCHED;
                 }
+                // else nextTask remains MATCHED, all iterations done.
             }
-        renameIterationTaskDefs(copy, iterationIndex);
-        return copy;
+        }
+
+        if (nextTask != null && nextTask != TaskDef.MATCHED) {
+            output.put(INNER_LAST_TASK, nextTask.getName());
+        }
+
+        return nextTask;
+    }
+    /**
+     * Traverses loop body children using flowExecutor.getNextTask() to properly
+     * support nested control-flow tasks (IF/SWITCH/SUB_FLOW). When getNextTask()
+     * returns MATCHED for a child, the next sibling is returned (or MATCHED if
+     * no more siblings exist). This follows the same pattern as IFTask/SwitchTask.
+     */
+    @SuppressWarnings("all")
+    private TaskDef findNextTaskFromChildren(final List<TaskDef> children,
+                                             final TaskDef target) {
+        Iterator<TaskDef> iterator = children.iterator();
+
+        while (iterator.hasNext()) {
+            TaskDef nextTask =
+                    flowExecutor.getNextTask(iterator.next(), target);
+            if (nextTask == TaskDef.MATCHED) {
+                return iterator.hasNext()
+                        ? iterator.next()
+                        : TaskDef.MATCHED;
+            } else if (nextTask != null) {
+                return nextTask;
+            }
+        }
+
+        return null;
     }
 
-    private void renameIterationTaskDefs(TaskDef root, int iterationIndex) {
-        Set<Object> visited = Collections.newSetFromMap(new java.util.IdentityHashMap<>());
-        renameIterationTaskDefsRecursively(root, iterationIndex, visited);
-    }
-
-    private void renameIterationTaskDefsRecursively(
-            Object node, int iterationIndex, Set<Object> visited) {
-        if (node == null || visited.contains(node)) {
-            return;
-        }
-        visited.add(node);
-
-        if (node instanceof TaskDef) {
-            TaskDef taskDef = (TaskDef) node;
-            if (taskDef.getName() != null) {
-                taskDef.setName(taskDef.getName() + LOOP_INDEX_SEPARATOR + iterationIndex);
-            }
-        }
-
-        if (node instanceof Map) {
-            for (Object value : ((Map<?, ?>) node).values()) {
-                renameIterationTaskDefsRecursively(value, iterationIndex, visited);
-            }
-            return;
-        }
-
-        if (node instanceof Iterable) {
-            for (Object value : (Iterable<?>) node) {
-                renameIterationTaskDefsRecursively(value, iterationIndex, visited);
-            }
-            return;
-        }
-
-        Class<?> nodeClass = node.getClass();
-        if (nodeClass.isArray()) {
-            int length = java.lang.reflect.Array.getLength(node);
-            for (int i = 0; i < length; i++) {
-                renameIterationTaskDefsRecursively(
-                        java.lang.reflect.Array.get(node, i), iterationIndex, visited);
-            }
-            return;
-        }
-
-        if (isTerminalObject(nodeClass)) {
-            return;
-        }
-
-        Class<?> currentClass = nodeClass;
-        while (currentClass != null && currentClass != Object.class) {
-            for (java.lang.reflect.Field field : currentClass.getDeclaredFields()) {
-                if (java.lang.reflect.Modifier.isStatic(field.getModifiers())
-                        || field.getType().isPrimitive()
-                        || field.isSynthetic()) {
-                    continue;
-                }
-                try {
-                    field.setAccessible(true);
-                    renameIterationTaskDefsRecursively(
-                            field.get(node), iterationIndex, visited);
-                } catch (IllegalAccessException ignored) {
-                    // Best-effort traversal: inaccessible fields are skipped.
-                }
-            }
-            currentClass = currentClass.getSuperclass();
-        }
-    }
-
-    private boolean isTerminalObject(Class<?> type) {
-        return type.isEnum()
-                || String.class.equals(type)
-                || Number.class.isAssignableFrom(type)
-                || Boolean.class.equals(type)
-                || Character.class.equals(type)
-                || Class.class.equals(type)
-                || type.getName().startsWith("java.time.")
-                || type.getName().startsWith("java.lang.");
-    }
     /**
      * Creates a deep copy of a TaskDef with an iteration-specific name suffix.
      * This ensures each iteration's tasks have unique names, preventing
@@ -426,17 +379,6 @@ public class LoopTask implements FlowTask {
     }
 
     /**
-     * Strips the iteration suffix ({@code __LOOP_N}) from a task name
-     * to recover the original name defined in loopBody.
-     */
-    static String stripIterationSuffix(String taskName) {
-        int sepIndex = taskName.lastIndexOf(LOOP_INDEX_SEPARATOR);
-        return sepIndex >= 0
-                ? taskName.substring(0, sepIndex)
-                : taskName;
-    }
-
-    /**
      * Extracts the iteration index from a suffixed task name.
      * Returns -1 if the name has no iteration suffix.
      */
@@ -449,19 +391,6 @@ public class LoopTask implements FlowTask {
                                 sepIndex + LOOP_INDEX_SEPARATOR.length()));
             } catch (NumberFormatException e) {
                 return -1;
-            }
-        }
-        return -1;
-    }
-
-    /**
-     * Finds the position of a task in the loop body by its original name.
-     */
-    private int findPositionInLoopBody(List<TaskDef> loopBody,
-                                       String originalName) {
-        for (int i = 0; i < loopBody.size(); i++) {
-            if (loopBody.get(i).getName().equals(originalName)) {
-                return i;
             }
         }
         return -1;

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -24,7 +24,6 @@ import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,7 +34,7 @@ import static xyz.mytang0.brook.core.utils.ParameterUtils.flowContext;
 /**
  * Loop task, used to iterate over a collection and execute child tasks for each element.
  * <p>
- * Supports two modes:
+ * Supports two mutually exclusive modes:
  * <ul>
  *   <li>{@code loopOver}: iterate over a list/collection expression</li>
  *   <li>{@code loopCount}: iterate a fixed number of times</li>
@@ -44,6 +43,9 @@ import static xyz.mytang0.brook.core.utils.ParameterUtils.flowContext;
  * During each iteration, the loop output exposes {@code currentIndex} and {@code currentItem}
  * (when using loopOver) so that child tasks can reference them via
  * {@code ${loopTaskName.output.currentIndex}} and {@code ${loopTaskName.output.currentItem}}.
+ * <p>
+ * Child task names are suffixed with {@code __LOOP_<index>} per iteration to ensure
+ * uniqueness across iterations (FlowExecutor deduplicates tasks by name).
  */
 public class LoopTask implements FlowTask {
 
@@ -60,9 +62,10 @@ public class LoopTask implements FlowTask {
 
     static final String ITERATIONS_KEY = "iterations";
 
-    static final String LOOP_OVER_VALUE_KEY = "loopOverValue";
-
     static final String INNER_LAST_TASK = "innerLastTask";
+
+    // Separator used to create per-iteration unique task names.
+    static final String LOOP_INDEX_SEPARATOR = "__LOOP_";
 
     private final EngineActuator engineActuator;
 
@@ -106,7 +109,7 @@ public class LoopTask implements FlowTask {
         }
         if (hasLoopOver && hasLoopCount) {
             throw new ValidationException(
-                    "Only one of 'loopOver' or 'loopCount' may be specified");
+                    "'loopOver' and 'loopCount' are mutually exclusive, specify only one");
         }
     }
 
@@ -123,17 +126,24 @@ public class LoopTask implements FlowTask {
         if (taskDefInput.contains(Options.LOOP_OVER)) {
             Object loopOverRaw = taskDefInput.get(Options.LOOP_OVER);
 
-            // Evaluate expression if engine type is provided.
-            Object evaluated = Optional.ofNullable(taskDefInput.getString(Options.ENGINE_TYPE))
-                    .filter(StringUtils::isNotBlank)
-                    .map(engineType ->
-                            engineActuator.compute(
-                                    engineType,
-                                    String.valueOf(loopOverRaw),
-                                    flowContext(context.getFlowInstance())
-                            )
-                    )
-                    .orElse(loopOverRaw);
+            // Only invoke the compute engine when the value is still a string expression.
+            // If the parameter has already been resolved to a List by parameter mapping,
+            // passing it through the engine would break (e.g., "[a, b]" is not a valid expression).
+            Object evaluated;
+            if (loopOverRaw instanceof String) {
+                evaluated = Optional.ofNullable(taskDefInput.getString(Options.ENGINE_TYPE))
+                        .filter(StringUtils::isNotBlank)
+                        .map(engineType ->
+                                engineActuator.compute(
+                                        engineType,
+                                        (String) loopOverRaw,
+                                        flowContext(context.getFlowInstance())
+                                )
+                        )
+                        .orElse(loopOverRaw);
+            } else {
+                evaluated = loopOverRaw;
+            }
 
             if (evaluated instanceof List) {
                 loopOverValue = (List<Object>) evaluated;
@@ -160,11 +170,8 @@ public class LoopTask implements FlowTask {
         Map<String, Object> loopOutput = new HashMap<>();
         loopOutput.put(ITERATIONS_KEY, iterations);
         loopOutput.put(CURRENT_INDEX_KEY, 0);
-        if (loopOverValue != null) {
-            loopOutput.put(LOOP_OVER_VALUE_KEY, loopOverValue);
-            if (!loopOverValue.isEmpty()) {
-                loopOutput.put(CURRENT_ITEM_KEY, loopOverValue.get(0));
-            }
+        if (loopOverValue != null && !loopOverValue.isEmpty()) {
+            loopOutput.put(CURRENT_ITEM_KEY, loopOverValue.get(0));
         }
         loopTask.setOutput(loopOutput);
 
@@ -204,13 +211,13 @@ public class LoopTask implements FlowTask {
         TaskInstance mappingTask = mappingTaskOptional.get();
 
         if (mappingTask.getOutput() == null) {
-            throw new IllegalStateException("LOOP task output must not be null when determining next task");
+            throw new IllegalStateException(
+                    "LOOP task output must not be null when determining next task");
         }
 
         Map<String, Object> output = mappingTask.getOutput();
 
         int iterations = (int) output.get(ITERATIONS_KEY);
-        int currentIndex = (int) output.get(CURRENT_INDEX_KEY);
 
         // No iterations needed.
         if (iterations <= 0) {
@@ -228,29 +235,40 @@ public class LoopTask implements FlowTask {
         if (toBeSearched == target
                 || toBeSearched.getName().equals(target.getName())) {
             // Starting the loop: return first child task of iteration 0.
-            nextTask = loopBody.get(0);
+            output.put(CURRENT_INDEX_KEY, 0);
+            nextTask = createIterationTaskDef(loopBody.get(0), 0);
         } else {
-            // Find next task within the current iteration's loop body.
-            nextTask = findNextTaskFromChildren(loopBody, target);
+            // Find the target's position in the loop body by stripping the iteration suffix.
+            String originalName = stripIterationSuffix(target.getName());
+            int iterationIndex = extractIterationIndex(target.getName());
 
-            // If we've exhausted the current iteration (MATCHED = last child completed),
-            // advance to next iteration.
-            if (nextTask == TaskDef.MATCHED) {
-                int nextIndex = currentIndex + 1;
+            int pos = findPositionInLoopBody(loopBody, originalName);
+
+            if (pos < 0) {
+                // Target not found in loop body.
+                return null;
+            }
+
+            int effectiveIndex = iterationIndex >= 0
+                    ? iterationIndex
+                    : (int) output.get(CURRENT_INDEX_KEY);
+
+            if (pos + 1 < loopBody.size()) {
+                // More tasks in the current iteration.
+                nextTask = createIterationTaskDef(
+                        loopBody.get(pos + 1), effectiveIndex);
+            } else {
+                // Last task in the current iteration, advance to next.
+                int nextIndex = effectiveIndex + 1;
                 if (nextIndex < iterations) {
-                    // Move to next iteration.
                     output.put(CURRENT_INDEX_KEY, nextIndex);
-
-                    // Update current item if loopOver mode.
-                    List<Object> loopOverValue = (List<Object>) output.get(LOOP_OVER_VALUE_KEY);
-                    if (loopOverValue != null && nextIndex < loopOverValue.size()) {
-                        output.put(CURRENT_ITEM_KEY, loopOverValue.get(nextIndex));
-                    }
-
-                    // Return first task of loop body for next iteration.
-                    nextTask = loopBody.get(0);
+                    updateCurrentItem(output, mappingTask, nextIndex);
+                    nextTask = createIterationTaskDef(
+                            loopBody.get(0), nextIndex);
+                } else {
+                    // All iterations done.
+                    nextTask = TaskDef.MATCHED;
                 }
-                // else nextTask remains MATCHED, meaning all iterations done.
             }
         }
 
@@ -259,6 +277,81 @@ public class LoopTask implements FlowTask {
         }
 
         return nextTask;
+    }
+
+    /**
+     * Creates a deep copy of a TaskDef with an iteration-specific name suffix.
+     * This ensures each iteration's tasks have unique names, preventing
+     * the executor's name-based deduplication from filtering them out.
+     */
+    private TaskDef createIterationTaskDef(TaskDef original, int iterationIndex) {
+        TaskDef copy = JsonUtils.readValue(
+                JsonUtils.toJsonString(original), TaskDef.class);
+        copy.setName(original.getName() + LOOP_INDEX_SEPARATOR + iterationIndex);
+        return copy;
+    }
+
+    /**
+     * Strips the iteration suffix ({@code __LOOP_N}) from a task name
+     * to recover the original name defined in loopBody.
+     */
+    static String stripIterationSuffix(String taskName) {
+        int sepIndex = taskName.lastIndexOf(LOOP_INDEX_SEPARATOR);
+        return sepIndex >= 0
+                ? taskName.substring(0, sepIndex)
+                : taskName;
+    }
+
+    /**
+     * Extracts the iteration index from a suffixed task name.
+     * Returns -1 if the name has no iteration suffix.
+     */
+    static int extractIterationIndex(String taskName) {
+        int sepIndex = taskName.lastIndexOf(LOOP_INDEX_SEPARATOR);
+        if (sepIndex >= 0) {
+            try {
+                return Integer.parseInt(
+                        taskName.substring(
+                                sepIndex + LOOP_INDEX_SEPARATOR.length()));
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Finds the position of a task in the loop body by its original name.
+     */
+    private int findPositionInLoopBody(List<TaskDef> loopBody,
+                                       String originalName) {
+        for (int i = 0; i < loopBody.size(); i++) {
+            if (loopBody.get(i).getName().equals(originalName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Updates the currentItem in the output for the given iteration index.
+     * Retrieves the loopOver collection from the LOOP task's resolved input,
+     * avoiding the need to store the full collection in the output.
+     */
+    @SuppressWarnings("all")
+    private void updateCurrentItem(Map<String, Object> output,
+                                   TaskInstance mappingTask,
+                                   int nextIndex) {
+        Map<String, Object> input = mappingTask.getInput();
+        if (input != null) {
+            Object loopOver = input.get(Options.LOOP_OVER.key());
+            if (loopOver instanceof List) {
+                List<Object> loopOverValue = (List<Object>) loopOver;
+                if (nextIndex < loopOverValue.size()) {
+                    output.put(CURRENT_ITEM_KEY, loopOverValue.get(nextIndex));
+                }
+            }
+        }
     }
 
     @SuppressWarnings("all")
@@ -274,7 +367,7 @@ public class LoopTask implements FlowTask {
 
                     if (!(taskDef.getInput() instanceof Map)) {
                         throw new IllegalArgumentException(
-                            "Loop task input must be a Map");
+                                "Loop task input must be a Map");
                     }
 
                     loopBody = JsonUtils.convertValue(
@@ -291,25 +384,6 @@ public class LoopTask implements FlowTask {
         return loopBody;
     }
 
-    @SuppressWarnings("all")
-    private TaskDef findNextTaskFromChildren(final List<TaskDef> children, final TaskDef target) {
-        Iterator<TaskDef> iterator = children.iterator();
-
-        while (iterator.hasNext()) {
-            TaskDef nextTask =
-                    flowExecutor.getNextTask(iterator.next(), target);
-            if (nextTask == TaskDef.MATCHED) {
-                return iterator.hasNext()
-                        ? iterator.next()
-                        : TaskDef.MATCHED;
-            } else if (nextTask != null) {
-                return nextTask;
-            }
-        }
-
-        return null;
-    }
-
     static class Options {
 
         static final ConfigOption<String> ENGINE_TYPE = ConfigOptions
@@ -323,14 +397,15 @@ public class LoopTask implements FlowTask {
                 .classType(Object.class)
                 .noDefaultValue()
                 .withDescription("The collection to iterate over. " +
-                        "Can be a list literal or an expression that evaluates to a list.");
+                        "Can be a list literal or an expression. " +
+                        "Mutually exclusive with 'loopCount'.");
 
         static final ConfigOption<Integer> LOOP_COUNT = ConfigOptions
                 .key("loopCount")
                 .intType()
                 .noDefaultValue()
                 .withDescription("The number of iterations to perform. " +
-                        "Used when iterating a fixed number of times instead of over a collection.");
+                        "Mutually exclusive with 'loopOver'.");
 
         static final ConfigOption<List<TaskDef>> LOOP_BODY = ConfigOptions
                 .key("loopBody")

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -1,0 +1,337 @@
+package xyz.mytang0.brook.core.tasks;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.Setter;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import xyz.mytang0.brook.common.configuration.ConfigOption;
+import xyz.mytang0.brook.common.configuration.ConfigOptions;
+import xyz.mytang0.brook.common.configuration.Configuration;
+import xyz.mytang0.brook.common.context.FlowContext;
+import xyz.mytang0.brook.common.context.TaskMapperContext;
+import xyz.mytang0.brook.common.extension.ExtensionDirector;
+import xyz.mytang0.brook.common.metadata.definition.TaskDef;
+import xyz.mytang0.brook.common.metadata.enums.TaskStatus;
+import xyz.mytang0.brook.common.metadata.instance.FlowInstance;
+import xyz.mytang0.brook.common.metadata.instance.TaskInstance;
+import xyz.mytang0.brook.common.utils.JsonUtils;
+import xyz.mytang0.brook.core.FlowExecutor;
+import xyz.mytang0.brook.spi.computing.EngineActuator;
+import xyz.mytang0.brook.spi.task.FlowTask;
+
+import javax.validation.ValidationException;
+import javax.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static xyz.mytang0.brook.core.utils.ParameterUtils.flowContext;
+
+/**
+ * Loop task, used to iterate over a collection and execute child tasks for each element.
+ * <p>
+ * Supports two modes:
+ * <ul>
+ *   <li>{@code loopOver}: iterate over a list/collection expression</li>
+ *   <li>{@code loopCount}: iterate a fixed number of times</li>
+ * </ul>
+ * <p>
+ * During each iteration, the loop output exposes {@code currentIndex} and {@code currentItem}
+ * (when using loopOver) so that child tasks can reference them via
+ * {@code ${loopTaskName.output.currentIndex}} and {@code ${loopTaskName.output.currentItem}}.
+ */
+public class LoopTask implements FlowTask {
+
+    static final ConfigOption<Map<String, Object>> CATALOG = ConfigOptions
+            .key("LOOP")
+            .classType(PROPERTIES_MAP_CLASS)
+            .noDefaultValue()
+            .withDescription("Loop task, used to iterate and execute child tasks for each element.");
+
+    // Output keys.
+    static final String CURRENT_INDEX_KEY = "currentIndex";
+
+    static final String CURRENT_ITEM_KEY = "currentItem";
+
+    static final String ITERATIONS_KEY = "iterations";
+
+    static final String LOOP_OVER_VALUE_KEY = "loopOverValue";
+
+    static final String INNER_LAST_TASK = "innerLastTask";
+
+    private final EngineActuator engineActuator;
+
+    @Setter
+    private FlowExecutor<?> flowExecutor;
+
+    public LoopTask() {
+        this.engineActuator = ExtensionDirector
+                .getExtensionLoader(EngineActuator.class)
+                .getDefaultExtension();
+    }
+
+    @Override
+    public ConfigOption<?> catalog() {
+        return CATALOG;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(Options.LOOP_BODY);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(Options.ENGINE_TYPE);
+        options.add(Options.LOOP_OVER);
+        options.add(Options.LOOP_COUNT);
+        return options;
+    }
+
+    @Override
+    public void doVerify(@NotNull Configuration configuration) {
+        boolean hasLoopOver = configuration.contains(Options.LOOP_OVER);
+        boolean hasLoopCount = configuration.contains(Options.LOOP_COUNT);
+        if (!hasLoopOver && !hasLoopCount) {
+            throw new ValidationException(
+                    "At least one of 'loopOver' or 'loopCount' must be specified");
+        }
+    }
+
+    @SuppressWarnings("all")
+    @Override
+    public List<TaskInstance> getMappedTasks(TaskMapperContext context) {
+
+        Configuration taskDefInput = context.getInputConfiguration();
+
+        int iterations;
+        List<Object> loopOverValue = null;
+
+        // Determine iteration count.
+        if (taskDefInput.contains(Options.LOOP_OVER)) {
+            Object loopOverRaw = taskDefInput.get(Options.LOOP_OVER);
+
+            // Evaluate expression if engine type is provided.
+            Object evaluated = Optional.ofNullable(taskDefInput.getString(Options.ENGINE_TYPE))
+                    .filter(StringUtils::isNotBlank)
+                    .map(engineType ->
+                            engineActuator.compute(
+                                    engineType,
+                                    String.valueOf(loopOverRaw),
+                                    flowContext(context.getFlowInstance())
+                            )
+                    )
+                    .orElse(loopOverRaw);
+
+            if (evaluated instanceof List) {
+                loopOverValue = (List<Object>) evaluated;
+            } else {
+                throw new IllegalArgumentException(
+                        "The loop task 'loopOver' must evaluate to a list, got: "
+                                + (evaluated == null ? "null" : evaluated.getClass().getName()));
+            }
+            iterations = loopOverValue.size();
+        } else {
+            Integer loopCount = taskDefInput.get(Options.LOOP_COUNT);
+            if (loopCount == null || loopCount < 0) {
+                throw new IllegalArgumentException(
+                        "The loop task 'loopCount' must be a non-negative integer");
+            }
+            iterations = loopCount;
+        }
+
+        // Build loop task self.
+        TaskInstance loopTask = TaskInstance.create(context.getTaskDef());
+        loopTask.setFlowId(context.getFlowInstance().getFlowId());
+        loopTask.setInput(context.getInput());
+
+        Map<String, Object> loopOutput = new HashMap<>();
+        loopOutput.put(ITERATIONS_KEY, iterations);
+        loopOutput.put(CURRENT_INDEX_KEY, 0);
+        if (loopOverValue != null) {
+            loopOutput.put(LOOP_OVER_VALUE_KEY, loopOverValue);
+            if (!loopOverValue.isEmpty()) {
+                loopOutput.put(CURRENT_ITEM_KEY, loopOverValue.get(0));
+            }
+        }
+        loopTask.setOutput(loopOutput);
+
+        return Collections.singletonList(loopTask);
+    }
+
+    @Override
+    public boolean execute(TaskInstance taskInstance) {
+        taskInstance.setStatus(TaskStatus.COMPLETED);
+        return true;
+    }
+
+    @SuppressWarnings("all")
+    @Override
+    public TaskDef next(final TaskDef toBeSearched, final TaskDef target) {
+
+        if (!getType().equals(toBeSearched.getType())) {
+            throw new IllegalArgumentException(
+                    String.format("The 'next' method cannot be executed, " +
+                                    "because the to be searched task type does not match, %s != %s",
+                            getType(), toBeSearched.getType()));
+        }
+
+        if (target == null) {
+            throw new IllegalArgumentException("The target task is null");
+        }
+
+        final FlowInstance currentFlow = FlowContext.getCurrentFlow();
+
+        Optional<TaskInstance> mappingTaskOptional =
+                currentFlow.getTaskByName(toBeSearched.getName());
+
+        if (!mappingTaskOptional.isPresent()) {
+            return null;
+        }
+
+        TaskInstance mappingTask = mappingTaskOptional.get();
+
+        if (mappingTask.getOutput() == null) {
+            throw new IllegalStateException("When next, the LOOP task output null");
+        }
+
+        Map<String, Object> output = mappingTask.getOutput();
+
+        int iterations = (int) output.get(ITERATIONS_KEY);
+        int currentIndex = (int) output.get(CURRENT_INDEX_KEY);
+
+        // No iterations needed.
+        if (iterations <= 0) {
+            return null;
+        }
+
+        final List<TaskDef> loopBody = getLoopBody(toBeSearched);
+
+        if (CollectionUtils.isEmpty(loopBody)) {
+            return null;
+        }
+
+        TaskDef nextTask;
+
+        if (toBeSearched == target
+                || toBeSearched.getName().equals(target.getName())) {
+            // Starting the loop: return first child task of iteration 0.
+            nextTask = loopBody.get(0);
+        } else {
+            // Find next task within the current iteration's loop body.
+            nextTask = findNextTaskFromChildren(loopBody, target);
+
+            // If we've exhausted the current iteration (MATCHED = last child completed),
+            // advance to next iteration.
+            if (nextTask == TaskDef.MATCHED) {
+                int nextIndex = currentIndex + 1;
+                if (nextIndex < iterations) {
+                    // Move to next iteration.
+                    output.put(CURRENT_INDEX_KEY, nextIndex);
+
+                    // Update current item if loopOver mode.
+                    List<Object> loopOverValue = (List<Object>) output.get(LOOP_OVER_VALUE_KEY);
+                    if (loopOverValue != null) {
+                        output.put(CURRENT_ITEM_KEY, loopOverValue.get(nextIndex));
+                    }
+
+                    // Return first task of loop body for next iteration.
+                    nextTask = loopBody.get(0);
+                }
+                // else nextTask remains MATCHED, meaning all iterations done.
+            }
+        }
+
+        if (nextTask != null && nextTask != TaskDef.MATCHED) {
+            output.put(INNER_LAST_TASK, nextTask.getName());
+        }
+
+        return nextTask;
+    }
+
+    @SuppressWarnings("all")
+    private List<TaskDef> getLoopBody(@NotNull final TaskDef taskDef) {
+        List<TaskDef> loopBody = taskDef.getParsed();
+
+        if (loopBody == null) {
+            synchronized (taskDef) {
+
+                loopBody = taskDef.getParsed();
+
+                if (loopBody == null) {
+
+                    if (!(taskDef.getInput() instanceof Map)) {
+                        throw new IllegalArgumentException("The loop task input type is not map");
+                    }
+
+                    loopBody = JsonUtils.convertValue(
+                            ((Map<String, Object>) taskDef.getInput())
+                                    .get(Options.LOOP_BODY.key()),
+                            new TypeReference<List<TaskDef>>() {
+                            }
+                    );
+
+                    taskDef.setParsed(loopBody);
+                }
+            }
+        }
+        return loopBody;
+    }
+
+    @SuppressWarnings("all")
+    private TaskDef findNextTaskFromChildren(final List<TaskDef> children, final TaskDef target) {
+        Iterator<TaskDef> iterator = children.iterator();
+
+        while (iterator.hasNext()) {
+            TaskDef nextTask =
+                    flowExecutor.getNextTask(iterator.next(), target);
+            if (nextTask == TaskDef.MATCHED) {
+                return iterator.hasNext()
+                        ? iterator.next()
+                        : TaskDef.MATCHED;
+            } else if (nextTask != null) {
+                return nextTask;
+            }
+        }
+
+        return null;
+    }
+
+    static class Options {
+
+        static final ConfigOption<String> ENGINE_TYPE = ConfigOptions
+                .key("engineType")
+                .stringType()
+                .noDefaultValue()
+                .withDescription("The expression evaluation engine type for loopOver.");
+
+        static final ConfigOption<Object> LOOP_OVER = ConfigOptions
+                .key("loopOver")
+                .classType(Object.class)
+                .noDefaultValue()
+                .withDescription("The collection to iterate over. " +
+                        "Can be a list literal or an expression that evaluates to a list.");
+
+        static final ConfigOption<Integer> LOOP_COUNT = ConfigOptions
+                .key("loopCount")
+                .intType()
+                .noDefaultValue()
+                .withDescription("The number of iterations to perform. " +
+                        "Used when iterating a fixed number of times instead of over a collection.");
+
+        static final ConfigOption<List<TaskDef>> LOOP_BODY = ConfigOptions
+                .key("loopBody")
+                .classType(TaskDef.class)
+                .asList()
+                .noDefaultValue()
+                .withDescription("The list of child task definitions to execute for each iteration.");
+    }
+}

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -187,6 +187,16 @@ public class LoopTask implements FlowTask {
         loopTask.setFlowId(context.getFlowInstance().getFlowId());
         loopTask.setInput(context.getInput());
 
+        // Persist the normalized list into the task input so that
+        // updateCurrentItem() can reliably index into it on later iterations,
+        // even when the original loopOver was an engine expression or a
+        // non-List collection/array that was normalized above.
+        if (loopOverValue != null && loopTask.getInput() instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> inputMap = (Map<String, Object>) loopTask.getInput();
+            inputMap.put(Options.LOOP_OVER.key(), loopOverValue);
+        }
+
         Map<String, Object> loopOutput = new HashMap<>();
         loopOutput.put(ITERATIONS_KEY, iterations);
         loopOutput.put(CURRENT_INDEX_KEY, 0);
@@ -303,12 +313,44 @@ public class LoopTask implements FlowTask {
      * Creates a deep copy of a TaskDef with an iteration-specific name suffix.
      * This ensures each iteration's tasks have unique names, preventing
      * the executor's name-based deduplication from filtering them out.
+     * <p>
+     * Recursively renames all nested child TaskDefs (e.g., inside IF/SWITCH
+     * branches) to prevent name collisions across iterations.
      */
     private TaskDef createIterationTaskDef(TaskDef original, int iterationIndex) {
+        String suffix = LOOP_INDEX_SEPARATOR + iterationIndex;
         TaskDef copy = JsonUtils.readValue(
                 JsonUtils.toJsonString(original), TaskDef.class);
-        copy.setName(original.getName() + LOOP_INDEX_SEPARATOR + iterationIndex);
+        copy.setName(original.getName() + suffix);
+        // Recursively rename any nested TaskDefs embedded in the input
+        // (e.g., IF trueBranch/falseBranch, SWITCH cases, nested LOOP body).
+        if (copy.getInput() != null) {
+            renameNestedTaskDefs(copy.getInput(), suffix);
+        }
         return copy;
+    }
+
+    /**
+     * Recursively walks an object tree (Maps and Lists from JSON) and renames
+     * any Map that looks like a TaskDef (has both "name" and "type" keys) by
+     * appending the given suffix to its "name" value.
+     */
+    @SuppressWarnings("unchecked")
+    private void renameNestedTaskDefs(Object obj, String suffix) {
+        if (obj instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) obj;
+            if (map.containsKey("name") && map.containsKey("type")
+                    && map.get("name") instanceof String) {
+                map.put("name", map.get("name") + suffix);
+            }
+            for (Object value : map.values()) {
+                renameNestedTaskDefs(value, suffix);
+            }
+        } else if (obj instanceof List) {
+            for (Object item : (List<?>) obj) {
+                renameNestedTaskDefs(item, suffix);
+            }
+        }
     }
 
     /**

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -23,6 +23,7 @@ import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,6 +71,15 @@ public class LoopTask implements FlowTask {
 
     // Separator used to create per-iteration unique task names.
     static final String LOOP_INDEX_SEPARATOR = "__LOOP_";
+
+    // Keys that are specific to TaskDef (beyond "name" and "type") used to
+    // distinguish real TaskDef Maps from arbitrary user payload Maps.
+    // A Map must have "name" + "type" AND at least one of these keys to be
+    // considered a TaskDef for per-iteration renaming.
+    private static final Set<String> TASK_DEF_INDICATOR_KEYS = new HashSet<>(Arrays.asList(
+            "input", "controlDef", "progressDef", "logDef", "linkDef",
+            "checkDef", "hangDef", "callback", "extension", "template"
+    ));
 
     private final EngineActuator engineActuator;
 
@@ -357,15 +367,19 @@ public class LoopTask implements FlowTask {
 
     /**
      * Recursively walks an object tree (Maps and Lists from JSON) and renames
-     * any Map that looks like a TaskDef (has both "name" and "type" keys) by
-     * appending the given suffix to its "name" value.
+     * any Map that looks like a TaskDef by appending the given suffix to its
+     * "name" value.
+     * <p>
+     * A Map is identified as a TaskDef only if it has both "name" and "type"
+     * (String values) AND at least one additional TaskDef-specific key
+     * (e.g., "input", "controlDef"). This prevents unintentional renaming of
+     * user payload objects that happen to have "name" and "type" keys.
      */
     @SuppressWarnings("unchecked")
     private void renameNestedTaskDefs(Object obj, String suffix) {
         if (obj instanceof Map) {
             Map<String, Object> map = (Map<String, Object>) obj;
-            if (map.containsKey("name") && map.containsKey("type")
-                    && map.get("name") instanceof String) {
+            if (isTaskDefMap(map)) {
                 map.put("name", map.get("name") + suffix);
             }
             for (Object value : map.values()) {
@@ -376,6 +390,26 @@ public class LoopTask implements FlowTask {
                 renameNestedTaskDefs(item, suffix);
             }
         }
+    }
+
+    /**
+     * Returns {@code true} if the given Map looks like a serialized TaskDef.
+     * Requires "name" and "type" as String values, plus at least one
+     * additional key that is specific to TaskDef structure (e.g., "input",
+     * "controlDef"), to avoid false positives on arbitrary user data.
+     */
+    private static boolean isTaskDefMap(Map<String, Object> map) {
+        if (!(map.containsKey("name") && map.containsKey("type")
+                && map.get("name") instanceof String
+                && map.get("type") instanceof String)) {
+            return false;
+        }
+        for (String key : TASK_DEF_INDICATOR_KEYS) {
+            if (map.containsKey(key)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/tasks/LoopTask.java
@@ -300,10 +300,87 @@ public class LoopTask implements FlowTask {
                     nextTask = TaskDef.MATCHED;
                 }
             }
+        renameIterationTaskDefs(copy, iterationIndex);
+        return copy;
+    }
+
+    private void renameIterationTaskDefs(TaskDef root, int iterationIndex) {
+        Set<Object> visited = Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+        renameIterationTaskDefsRecursively(root, iterationIndex, visited);
+    }
+
+    private void renameIterationTaskDefsRecursively(
+            Object node, int iterationIndex, Set<Object> visited) {
+        if (node == null || visited.contains(node)) {
+            return;
+        }
+        visited.add(node);
+
+        if (node instanceof TaskDef) {
+            TaskDef taskDef = (TaskDef) node;
+            if (taskDef.getName() != null) {
+                taskDef.setName(taskDef.getName() + LOOP_INDEX_SEPARATOR + iterationIndex);
+            }
         }
 
-        if (nextTask != null && nextTask != TaskDef.MATCHED) {
-            output.put(INNER_LAST_TASK, nextTask.getName());
+        if (node instanceof Map) {
+            for (Object value : ((Map<?, ?>) node).values()) {
+                renameIterationTaskDefsRecursively(value, iterationIndex, visited);
+            }
+            return;
+        }
+
+        if (node instanceof Iterable) {
+            for (Object value : (Iterable<?>) node) {
+                renameIterationTaskDefsRecursively(value, iterationIndex, visited);
+            }
+            return;
+        }
+
+        Class<?> nodeClass = node.getClass();
+        if (nodeClass.isArray()) {
+            int length = java.lang.reflect.Array.getLength(node);
+            for (int i = 0; i < length; i++) {
+                renameIterationTaskDefsRecursively(
+                        java.lang.reflect.Array.get(node, i), iterationIndex, visited);
+            }
+            return;
+        }
+
+        if (isTerminalObject(nodeClass)) {
+            return;
+        }
+
+        Class<?> currentClass = nodeClass;
+        while (currentClass != null && currentClass != Object.class) {
+            for (java.lang.reflect.Field field : currentClass.getDeclaredFields()) {
+                if (java.lang.reflect.Modifier.isStatic(field.getModifiers())
+                        || field.getType().isPrimitive()
+                        || field.isSynthetic()) {
+                    continue;
+                }
+                try {
+                    field.setAccessible(true);
+                    renameIterationTaskDefsRecursively(
+                            field.get(node), iterationIndex, visited);
+                } catch (IllegalAccessException ignored) {
+                    // Best-effort traversal: inaccessible fields are skipped.
+                }
+            }
+            currentClass = currentClass.getSuperclass();
+        }
+    }
+
+    private boolean isTerminalObject(Class<?> type) {
+        return type.isEnum()
+                || String.class.equals(type)
+                || Number.class.isAssignableFrom(type)
+                || Boolean.class.equals(type)
+                || Character.class.equals(type)
+                || Class.class.equals(type)
+                || type.getName().startsWith("java.time.")
+                || type.getName().startsWith("java.lang.");
+    }
         }
 
         return nextTask;

--- a/brook-core/src/main/java/xyz/mytang0/brook/core/utils/ParameterUtils.java
+++ b/brook-core/src/main/java/xyz/mytang0/brook/core/utils/ParameterUtils.java
@@ -8,6 +8,7 @@ import xyz.mytang0.brook.common.metadata.instance.FlowInstance;
 import xyz.mytang0.brook.common.metadata.instance.TaskInstance;
 import xyz.mytang0.brook.common.utils.JsonUtils;
 import xyz.mytang0.brook.core.constants.FlowConstants;
+import xyz.mytang0.brook.core.tasks.LoopTask;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -24,6 +25,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -350,9 +352,47 @@ public abstract class ParameterUtils {
         context.put(FlowConstants.FLOW, flowContext);
 
         if (CollectionUtils.isNotEmpty(flowInstance.getTaskInstances())) {
-            flowInstance.getTaskInstances().forEach(taskInstance ->
-                    context.put(taskInstance.getTaskDef().getName(), taskContext(taskInstance))
-            );
+            // Track the highest iteration index seen per loop-body base name, paired with
+            // its task context. This allows aliasing "X" -> the latest "X__LOOP_N" entry,
+            // so loop-body tasks can reference sibling outputs by their original (unsuffixed)
+            // names, e.g. ${processItem.output.result} instead of
+            // ${processItem__LOOP_0.output.result}.
+            final Map<String, Map.Entry<Integer, Map<String, Object>>> loopAliases =
+                    new HashMap<>();
+
+            flowInstance.getTaskInstances().forEach(taskInstance -> {
+                String taskName = taskInstance.getTaskDef().getName();
+                Map<String, Object> tc = taskContext(taskInstance);
+                context.put(taskName, tc);
+
+                // Detect names ending with __LOOP_<digits> (e.g. "processItem__LOOP_2").
+                // lastIndexOf is used intentionally: for nested loops the last suffix is
+                // stripped first, and each nesting level gets its own alias independently.
+                int sepIdx = taskName.lastIndexOf(LoopTask.LOOP_INDEX_SEPARATOR);
+                if (sepIdx > 0) {
+                    String indexPart = taskName.substring(
+                            sepIdx + LoopTask.LOOP_INDEX_SEPARATOR.length());
+                    try {
+                        int iterIdx = Integer.parseInt(indexPart);
+                        String baseName = taskName.substring(0, sepIdx);
+                        Map.Entry<Integer, Map<String, Object>> prev =
+                                loopAliases.get(baseName);
+                        if (prev == null || iterIdx > prev.getKey()) {
+                            loopAliases.put(baseName,
+                                    new AbstractMap.SimpleEntry<>(iterIdx, tc));
+                        }
+                    } catch (NumberFormatException e) {
+                        log.debug("Task name '{}' contains loop separator '{}' but has a "
+                                        + "non-numeric suffix; skipping loop alias.",
+                                taskName, LoopTask.LOOP_INDEX_SEPARATOR);
+                    }
+                }
+            });
+
+            // Register aliases only when no non-suffixed task with the same base name exists,
+            // to avoid shadowing an explicit top-level task that happens to share a name.
+            loopAliases.forEach((baseName, entry) ->
+                    context.putIfAbsent(baseName, entry.getValue()));
         }
 
         return context;

--- a/brook-core/src/main/resources/META-INF/brook/xyz.mytang0.brook.spi.task.FlowTask
+++ b/brook-core/src/main/resources/META-INF/brook/xyz.mytang0.brook.spi.task.FlowTask
@@ -3,3 +3,4 @@ SWITCH=xyz.mytang0.brook.core.tasks.SwitchTask
 SUB_FLOW=xyz.mytang0.brook.core.tasks.SubFlowTask
 COMPUTING=xyz.mytang0.brook.core.tasks.ComputingTask
 WAIT=xyz.mytang0.brook.core.tasks.WaitTask
+LOOP=xyz.mytang0.brook.core.tasks.LoopTask

--- a/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
+++ b/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
@@ -1,0 +1,22 @@
+{
+  "name": "test-loop",
+  "description": "Loop task demo - iterates over a list and processes each item",
+  "taskDefs": [
+    {
+      "type": "LOOP",
+      "name": "loopItems",
+      "input": {
+        "loopOver": "${flow.input.items}",
+        "loopBody": [
+          {
+            "type": "COMPUTING",
+            "name": "processItem",
+            "input": {
+              "source": "${loopItems.output.currentItem}"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
+++ b/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
@@ -1,21 +1,12 @@
 {
   "name": "test-loop",
-  "description": "Loop task demo - iterates over a list and processes each item",
+  "description": "Single-item processing demo used until LOOP supports per-iteration task identity",
   "taskDefs": [
     {
-      "type": "LOOP",
-      "name": "loopItems",
+      "type": "COMPUTING",
+      "name": "processItem",
       "input": {
-        "loopOver": "${flow.input.items}",
-        "loopBody": [
-          {
-            "type": "COMPUTING",
-            "name": "processItem",
-            "input": {
-              "source": "${loopItems.output.currentItem}"
-            }
-          }
-        ]
+        "source": "${flow.input.items[0]}"
       }
     }
   ]

--- a/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
+++ b/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
@@ -1,6 +1,6 @@
 {
   "name": "test-loop",
-  "description": "Loop task demo - iterates over a list and processes each item. Child task names are automatically suffixed with __LOOP_<index> per iteration (e.g., processItem__LOOP_0, processItem__LOOP_1) to ensure uniqueness.",
+  "description": "Loop task demo - iterates over a list and processes each item. Child task names are automatically suffixed with __LOOP_<index> per iteration (e.g., processItem__LOOP_0, processItem__LOOP_1) to ensure uniqueness. Loop-body tasks can reference sibling tasks by their original (unsuffixed) names, e.g. ${processItem.output.result}.",
   "taskDefs": [
     {
       "type": "LOOP",
@@ -14,6 +14,13 @@
             "input": {
               "source": "${loopItems.output.currentItem}"
             }
+          },
+          {
+            "type": "COMPUTING",
+            "name": "formatItem",
+            "input": {
+              "source": "${processItem.output.result}"
+            }
           }
         ]
       }
@@ -22,7 +29,7 @@
       "type": "COMPUTING",
       "name": "compute",
       "input": {
-        "source": "${loopItems.output.currentItem}"
+        "source": "${loopItems.output.iterations}"
       }
     }
   ]

--- a/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
+++ b/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
@@ -1,12 +1,22 @@
 {
   "name": "test-loop",
-  "description": "Single-item processing demo used until LOOP supports per-iteration task identity",
+  "description": "Loop task demo - iterates over a list and processes each item. Child task names are automatically suffixed with __LOOP_<index> per iteration (e.g., processItem__LOOP_0, processItem__LOOP_1) to ensure uniqueness.",
   "taskDefs": [
     {
-      "type": "COMPUTING",
-      "name": "processItem",
+      "type": "LOOP",
+      "name": "loopItems",
       "input": {
-        "source": "${flow.input.items[0]}"
+        "loopOver": "${flow.input.items}",
+        "loopBody": [
+          {
+            "type": "COMPUTING",
+            "name": "processItem",
+            "input": {
+              "source": "${loopItems.output.currentItem}",
+              "index": "${loopItems.output.currentIndex}"
+            }
+          }
+        ]
       }
     }
   ]

--- a/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
+++ b/brook-demo/brook-demo-spring/src/main/resources/META-INF/flows/test-loop.json
@@ -12,11 +12,17 @@
             "type": "COMPUTING",
             "name": "processItem",
             "input": {
-              "source": "${loopItems.output.currentItem}",
-              "index": "${loopItems.output.currentIndex}"
+              "source": "${loopItems.output.currentItem}"
             }
           }
         ]
+      }
+    },
+    {
+      "type": "COMPUTING",
+      "name": "compute",
+      "input": {
+        "source": "${loopItems.output.currentItem}"
       }
     }
   ]


### PR DESCRIPTION
This pull request introduces support for a new `LOOP` task type in the core task definitions and demonstrates its usage with a new flow example. The main focus is on enabling iteration over lists within flows, allowing child tasks to be executed for each item.

**Core task system enhancements:**

* Added the `LOOP` task type to the core task registration in `FlowTask`, enabling flows to define iterative logic over collections.

**Demo and documentation:**

* Added a new flow definition `test-loop.json` demonstrating the `LOOP` task, showing how to process each item in a list and how child task names are automatically suffixed for uniqueness.